### PR TITLE
Fixes backwards compatibility with WordPress version prior to 5.9

### DIFF
--- a/includes/classes/Helper.php
+++ b/includes/classes/Helper.php
@@ -16,6 +16,11 @@ class Helper {
 	 */
 	public static function providers() {
 		$json_file = OOTB_PLUGIN_PATH . 'assets/providers.json';
+		if ( ! function_exists( 'wp_json_file_decode' ) ) {
+			$request = file_get_contents( $json_file );
+
+			return json_decode( $request );
+		}
 
 		return wp_json_file_decode( $json_file );
 	}
@@ -134,7 +139,11 @@ class Helper {
 		if ( ! str_contains( $timezone, '/' ) ) {
 			return self::fallback_location();
 		}
-		$defaults = wp_json_file_decode( OOTB_PLUGIN_PATH . '/assets/defaults.json', true );
+		if ( function_exists( 'wp_json_file_decode' ) ) {
+			$defaults = wp_json_file_decode( OOTB_PLUGIN_PATH . '/assets/defaults.json', true );
+		} else {
+			$defaults = json_decode( file_get_contents( OOTB_PLUGIN_PATH . '/assets/defaults.json' ) );
+		}
 		$column = array_column( $defaults, 'timezone' );
 		$entry  = array_search( $timezone, $column );
 		if ( empty( $defaults[ $entry ] ) || empty( $defaults[ $entry ]->lat ) || empty( $defaults[ $entry ]->lng ) ) {

--- a/ootb-openstreetmap.php
+++ b/ootb-openstreetmap.php
@@ -5,7 +5,7 @@
  * Description:       A map block for the Gutenberg Editor using OpenStreetMaps and Leaflet that needs no API keys and works out of the box.
  * Requires at least: 5.8
  * Requires PHP:      7.4
- * Version:           2.0.0
+ * Version:           2.0.1
  * Author:            Giorgos Sarigiannidis
  * Author URI:        https://www.gsarigiannidis.gr
  * License:           GPL-2.0-or-later
@@ -21,7 +21,7 @@ define( 'OOTB_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
 define( 'OOTB_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 
 const OOTB_BLOCK_NAME = 'ootb/openstreetmap';
-const OOTB_VERSION    = '2.0.0';
+const OOTB_VERSION    = '2.0.1';
 const OOTB_PLUGIN_INC = OOTB_PLUGIN_PATH . 'includes/';
 
 // Require Composer autoloader if it exists.

--- a/ootb-openstreetmap.php
+++ b/ootb-openstreetmap.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Out of the Block: OpenStreetMap
  * Plugin URI:        https://wordpress.org/plugins/ootb-openstreetmap/
  * Description:       A map block for the Gutenberg Editor using OpenStreetMaps and Leaflet that needs no API keys and works out of the box.
- * Requires at least: 5.8
+ * Requires at least: 5.8.6
  * Requires PHP:      7.4
  * Version:           2.0.1
  * Author:            Giorgos Sarigiannidis

--- a/readme.txt
+++ b/readme.txt
@@ -2,10 +2,10 @@
 Contributors: gsarig
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=MZR4JSRUMH5EA&source=url
 Tags: Map, OpenStreetMap, Leaflet, Google Maps, block
-Requires at least: 5.9
+Requires at least: 5.8.6
 Tested up to: 6.1
 Requires PHP: 7.4
-Stable tag: 2.0.0
+Stable tag: 2.0.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -80,6 +80,9 @@ Version 2.0.0 is a major, almost full, refactoring, both for the build scripts a
 = 1.0 =
 
 == Changelog ==
+
+= 2.0.1 =
+* Fixes a bug which broke the admin on WordPress versions prior to 5.9.
 
 = 2.0.0 =
 * Refactors the build scripts to use the official `@wordpress/create-block` instead of `create-guten-block`, which isn't supported anymore.


### PR DESCRIPTION
* Addresses the issue reported [here](https://wordpress.org/support/topic/uncaught-error-call-to-undefined-function-ootbwp_json_file_decode/)