### PR TITLE
version 2.0.2

### DIFF
--- a/includes/classes/Helper.php
+++ b/includes/classes/Helper.php
@@ -136,7 +136,7 @@ class Helper {
 		}
 		$timezone = wp_timezone_string();
 		// Return empty if a manual timezone is set.
-		if ( ! str_contains( $timezone, '/' ) ) {
+		if ( false === strpos( $timezone, '/' ) ) {
 			return self::fallback_location();
 		}
 		if ( function_exists( 'wp_json_file_decode' ) ) {

--- a/ootb-openstreetmap.php
+++ b/ootb-openstreetmap.php
@@ -5,7 +5,7 @@
  * Description:       A map block for the Gutenberg Editor using OpenStreetMaps and Leaflet that needs no API keys and works out of the box.
  * Requires at least: 5.8.6
  * Requires PHP:      7.4
- * Version:           2.0.1
+ * Version:           2.0.2
  * Author:            Giorgos Sarigiannidis
  * Author URI:        https://www.gsarigiannidis.gr
  * License:           GPL-2.0-or-later
@@ -21,7 +21,7 @@ define( 'OOTB_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
 define( 'OOTB_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 
 const OOTB_BLOCK_NAME = 'ootb/openstreetmap';
-const OOTB_VERSION    = '2.0.1';
+const OOTB_VERSION    = '2.0.2';
 const OOTB_PLUGIN_INC = OOTB_PLUGIN_PATH . 'includes/';
 
 // Require Composer autoloader if it exists.

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: Map, OpenStreetMap, Leaflet, Google Maps, block
 Requires at least: 5.8.6
 Tested up to: 6.1
 Requires PHP: 7.4
-Stable tag: 2.0.1
+Stable tag: 2.0.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -80,6 +80,9 @@ Version 2.0.0 is a major, almost full, refactoring, both for the build scripts a
 = 1.0 =
 
 == Changelog ==
+
+= 2.0.2 =
+* Replaces `str_contains` with `strpos`, for better backwards compatibility with older versions of PHP / WordPress.
 
 = 2.0.1 =
 * Fixes a bug which broke the admin on WordPress versions prior to 5.9.


### PR DESCRIPTION
* Replaces `str_contains` with `strpos`, for better backwards compatibility with older versions of PHP / WordPress.