### PR TITLE
Fix editor crash on post types without custom-fields support

### DIFF
--- a/docker/mu-plugins/poi-cpt-fixture.php
+++ b/docker/mu-plugins/poi-cpt-fixture.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Plugin Name: OOTB Test Fixture — POI CPT
+ * Description: Registers a 'poi' custom post type WITHOUT custom-fields support, used by the geodata-cpt Playwright spec to guard against the editor crash fixed in PR #154.
+ */
+
+add_action(
+	'init',
+	function () {
+		register_post_type(
+			'poi',
+			[
+				'label'        => 'Points of Interest',
+				'public'       => true,
+				'show_in_rest' => true,
+				'supports'     => [ 'title', 'editor' ], // Deliberately NO 'custom-fields'.
+			]
+		);
+	}
+);

--- a/scripts/wp-artifact-setup.sh
+++ b/scripts/wp-artifact-setup.sh
@@ -70,7 +70,7 @@ wp plugin activate ootb-openstreetmap || {
 }
 
 echo "==> Setting default plugin options..."
-wp option update ootb_options '{"prevent_default_gestures":"","api_mapbox":"","api_openai":"","global_mapbox_style_url":""}' --format=json
+wp option update ootb_options '{"prevent_default_gestures":"","api_mapbox":"","api_openai":"","global_mapbox_style_url":"","geodata":"1","geo_post_types":{"poi":"1"}}' --format=json
 
 echo "==> Creating test page..."
 MARKER_ICON='%7B%22iconUrl%22%3A%22http%3A%2F%2Flocalhost%3A8080%2Fwp-content%2Fplugins%2Footb-openstreetmap%2Fassets%2Fvendor%2Fleaflet%2Fimages%2Fmarker-icon.png%22%2C%22iconAnchor%22%3A%5B12%2C41%5D%2C%22popupAnchor%22%3A%5B0%2C-41%5D%7D'

--- a/scripts/wp-artifact-setup.sh
+++ b/scripts/wp-artifact-setup.sh
@@ -70,7 +70,11 @@ wp plugin activate ootb-openstreetmap || {
 }
 
 echo "==> Setting default plugin options..."
-wp option update ootb_options '{"prevent_default_gestures":"","api_mapbox":"","api_openai":"","global_mapbox_style_url":"","geodata":"1","geo_post_types":{"poi":"1"}}' --format=json
+wp option update ootb_options '{"prevent_default_gestures":"","api_mapbox":"","api_openai":"","global_mapbox_style_url":""}' --format=json
+
+echo "==> Enabling geodata for the poi test CPT..."
+wp option patch insert ootb_options geodata '"1"' --format=json
+wp option patch insert ootb_options geo_post_types '{"poi":"1"}' --format=json
 
 echo "==> Creating test page..."
 MARKER_ICON='%7B%22iconUrl%22%3A%22http%3A%2F%2Flocalhost%3A8080%2Fwp-content%2Fplugins%2Footb-openstreetmap%2Fassets%2Fvendor%2Fleaflet%2Fimages%2Fmarker-icon.png%22%2C%22iconAnchor%22%3A%5B12%2C41%5D%2C%22popupAnchor%22%3A%5B0%2C-41%5D%7D'

--- a/scripts/wp-test-setup.sh
+++ b/scripts/wp-test-setup.sh
@@ -42,7 +42,7 @@ wp plugin activate ootb-openstreetmap || {
 }
 
 echo "==> Setting default plugin options..."
-wp option update ootb_options '{"prevent_default_gestures":"","api_mapbox":"","api_openai":"","global_mapbox_style_url":""}' --format=json
+wp option update ootb_options '{"prevent_default_gestures":"","api_mapbox":"","api_openai":"","global_mapbox_style_url":"","geodata":"1","geo_post_types":{"poi":"1"}}' --format=json
 
 if [ -n "${MAPBOX_ACCESS_TOKEN:-}" ]; then
   MAPBOX_STYLE="${MAPBOX_STYLE_URL:-mapbox://styles/mapbox/streets-v11}"

--- a/scripts/wp-test-setup.sh
+++ b/scripts/wp-test-setup.sh
@@ -42,7 +42,11 @@ wp plugin activate ootb-openstreetmap || {
 }
 
 echo "==> Setting default plugin options..."
-wp option update ootb_options '{"prevent_default_gestures":"","api_mapbox":"","api_openai":"","global_mapbox_style_url":"","geodata":"1","geo_post_types":{"poi":"1"}}' --format=json
+wp option update ootb_options '{"prevent_default_gestures":"","api_mapbox":"","api_openai":"","global_mapbox_style_url":""}' --format=json
+
+echo "==> Enabling geodata for the poi test CPT..."
+wp option patch insert ootb_options geodata '"1"' --format=json
+wp option patch insert ootb_options geo_post_types '{"poi":"1"}' --format=json
 
 if [ -n "${MAPBOX_ACCESS_TOKEN:-}" ]; then
   MAPBOX_STYLE="${MAPBOX_STYLE_URL:-mapbox://styles/mapbox/streets-v11}"

--- a/src/custom-fields/Elements/MapCustomField.js
+++ b/src/custom-fields/Elements/MapCustomField.js
@@ -50,7 +50,9 @@ function MapCustomField({geoAddress, geoLatitude, geoLongitude, setMetaValues}) 
 export default compose([
     withSelect((select) => {
         const {getEditedPostAttribute} = select('core/editor');
-        const meta = getEditedPostAttribute('meta');
+        // Post types without `custom-fields` support expose no meta over REST,
+        // in which case getEditedPostAttribute('meta') returns undefined.
+        const meta = getEditedPostAttribute('meta') ?? {};
         return {
             meta,
             geoAddress: meta['geo_address'],

--- a/src/custom-fields/Elements/MapCustomField.js
+++ b/src/custom-fields/Elements/MapCustomField.js
@@ -52,18 +52,25 @@ export default compose([
         const {getEditedPostAttribute} = select('core/editor');
         // Post types without `custom-fields` support expose no meta over REST,
         // in which case getEditedPostAttribute('meta') returns undefined.
-        const meta = getEditedPostAttribute('meta') ?? {};
+        const rawMeta = getEditedPostAttribute('meta');
+        const meta = rawMeta ?? {};
         return {
             meta,
+            metaSupported: rawMeta != null,
             geoAddress: meta['geo_address'],
             geoLatitude: meta['geo_latitude'],
             geoLongitude: meta['geo_longitude'],
         };
     }),
-    withDispatch((dispatch, {meta}) => {
+    withDispatch((dispatch, {meta, metaSupported}) => {
         const {editPost} = dispatch('core/editor');
         return {
             setMetaValues: (values) => {
+                // Without REST-exposed meta there is nothing to save; dispatching
+                // editPost would only mark the post dirty with a phantom edit.
+                if (!metaSupported) {
+                    return;
+                }
                 editPost({meta: {...meta, ...values}});
             }
         }

--- a/tests/playwright/geodata-cpt.spec.ts
+++ b/tests/playwright/geodata-cpt.spec.ts
@@ -51,6 +51,13 @@ test.describe( 'Geodata panel on a CPT without custom-fields support', () => {
 
     // No uncaught JS errors (the pre-fix crash surfaced here as a TypeError on 'geo_address')
     expect( jsErrors ).toHaveLength( 0 );
+
+    // The untouched post must not be marked dirty by a phantom meta edit
+    // (setMetaValues no-ops when meta is not exposed over REST)
+    const isDirty = await page.evaluate(
+      () => ( window as any ).wp.data.select( 'core/editor' ).isEditedPostDirty()
+    );
+    expect( isDirty ).toBe( false );
   } );
 
 } );

--- a/tests/playwright/geodata-cpt.spec.ts
+++ b/tests/playwright/geodata-cpt.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test';
+import { loginIfNeeded, dismissModals } from './helpers';
+
+/**
+ * Regression test for the geodata custom fields panel crash (PR #154).
+ *
+ * The 'poi' CPT (registered by docker/mu-plugins/poi-cpt-fixture.php) has no
+ * 'custom-fields' support, so getEditedPostAttribute('meta') returns undefined
+ * in its editor. Before the guard, rendering the Location panel crashed the
+ * whole editor with "Cannot read properties of undefined (reading 'geo_address')".
+ */
+test.describe( 'Geodata panel on a CPT without custom-fields support', () => {
+
+  test( 'Location panel renders without crashing the editor', async ({ page }) => {
+    await loginIfNeeded( page );
+    await dismissModals( page );
+
+    // Collect uncaught JS errors from the very start: the panel may be open
+    // on load, which is exactly how the original crash presented.
+    const jsErrors: string[] = [];
+    page.on( 'pageerror', err => jsErrors.push( err.message ) );
+
+    await page.goto( '/wp-admin/post-new.php?post_type=poi' );
+    await expect( page.locator( '.block-editor-writing-flow' ) ).toBeVisible( { timeout: 15_000 } );
+
+    // Dismiss the block editor welcome guide if present
+    const editorWelcome = page.locator(
+      '.components-modal__header button[aria-label="Close"], .edit-post-welcome-guide .components-button'
+    );
+    if ( await editorWelcome.count() ) {
+      await editorWelcome.first().click().catch( () => {} );
+    }
+
+    // Expand the Location panel if it is collapsed (its open state persists per user)
+    const locationPanel = page.locator( '.components-panel__body-toggle', { hasText: 'Location' } );
+    await expect( locationPanel ).toBeVisible( { timeout: 10_000 } );
+    const isOpen = await locationPanel.evaluate(
+      el => el.closest( '.components-panel__body' )?.classList.contains( 'is-opened' )
+    );
+    if ( ! isOpen ) {
+      await locationPanel.click();
+    }
+
+    // The panel content must render with its map
+    await expect(
+      page.locator( '.ootb-openstreetmap--custom-fields-container .leaflet-container' )
+    ).toBeVisible( { timeout: 15_000 } );
+
+    // The editor must not have crashed into its error boundary
+    await expect( page.locator( '.editor-error-boundary' ) ).toHaveCount( 0 );
+
+    // No uncaught JS errors (the pre-fix crash surfaced here as a TypeError on 'geo_address')
+    expect( jsErrors ).toHaveLength( 0 );
+  } );
+
+} );


### PR DESCRIPTION
## Summary
Guards `getEditedPostAttribute('meta')` in the geodata custom fields panel. Post types registered without `custom-fields` support expose no meta over REST, so the selector returns `undefined` and the panel crashed the whole editor when dereferencing it (`meta['geo_address']`).

Reported on the wp.org support forum: [Unable to make it work with a CPT](https://wordpress.org/support/topic/unable-to-make-it-work-with-a-cpt-%f0%9f%a4%94/) (WP 7.0, PHP 8.3, Pods-registered CPT).

Note: saving geodata still requires the post type to support `custom-fields`; this fix stops the crash so the editor stays usable.

## Testing
- `make lint` — pass
- `make phpunit-docker` — 69 tests pass
- `make playwright` — 7 tests pass
